### PR TITLE
New script: fix missing `img src` from nearby `a href`

### DIFF
--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -277,6 +277,7 @@ class Fixers extends \WP_CLI_Command {
 		);
 		$xpath = new \DOMXPath( $dom );
 
+		$replaced_image = false;
 
 		// Find links with any href value (that wrap images with a blank src).
 		foreach ( $xpath->query( '//a[@href]/img[@src=""]/..' ) as $anchor_element ) {
@@ -289,10 +290,14 @@ class Fixers extends \WP_CLI_Command {
 
 			// Find images wrapped by that anchor, and set the src.
 			foreach ( $xpath->query( './img[@src=""]', $anchor_element ) as $img_element ) {
+				$replaced_image = true;
 				$img_element->setAttribute( 'src', $image_url );
 			}
 		}
 
+		if ( ! $replaced_image ) {
+			return $text;
+		}
 
 		// $text was wrapped in a <div> tag to avoid DOMDocument changing things, so remove it.
 		$text = trim( $dom->saveHTML( $dom->getElementsByTagName('div')->item( 0 ) ) );

--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -210,7 +210,7 @@ class Fixers extends \WP_CLI_Command {
 		 * Keep calling get_posts() until we run out of posts to check.
 		 */
 		while ( ( $posts = get_posts( $post_args ) ) !== array() ) {
-			\WP_CLI::log( sprintf( "\nSearching %d posts...", $posts ) );
+			\WP_CLI::log( "\nSearching posts..." );
 
 			foreach ( $posts as $post ) {
 				$text = $post->post_content;

--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -220,7 +220,7 @@ class Fixers extends \WP_CLI_Command {
 					continue;
 				}
 
-				$new_text = self::replace_img_src_links_in_text( $text );
+				$new_text = self::replace_img_src_a_href( $text );
 				if ( $new_text === $text ) {
 					continue;
 				}
@@ -301,7 +301,7 @@ class Fixers extends \WP_CLI_Command {
 	 * @param string $text
 	 * @return string
 	 */
-	static public function replace_img_src_links_in_text( $text ) {
+	static public function replace_img_src_a_href( $text ) {
 		$dom   = new \DOMDocument();
 		$dom->loadHTML( '<div>' . $text . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 		$xpath = new \DOMXPath( $dom );

--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -247,9 +247,9 @@ class Fixers extends \WP_CLI_Command {
 				} else {
 					\WP_CLI::log( "\tDry-run mode enabled; post not updated." );
 				}
-
-				$post_args['offset'] += $limit;  // Keep the loop loopin'.
 			}
+
+			$post_args['offset'] += $limit;  // Keep the loop loopin'.
 		}
 
 		libxml_clear_errors();

--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -271,7 +271,10 @@ class Fixers extends \WP_CLI_Command {
 	 */
 	static public function replace_img_src_a_href( $text ) {
 		$dom   = new \DOMDocument();
-		$dom->loadHTML( '<div>' . $text . '</div>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		$dom->loadHTML(
+			mb_convert_encoding( '<div>' . $text . '</div>', 'HTML-ENTITIES', 'UTF-8' ),
+			LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+		);
 		$xpath = new \DOMXPath( $dom );
 
 
@@ -292,19 +295,11 @@ class Fixers extends \WP_CLI_Command {
 
 
 		// $text was wrapped in a <div> tag to avoid DOMDocument changing things, so remove it.
-		$container = $dom->getElementsByTagName( 'div' )->item( 0 );
-		$container = $container->parentNode->removeChild( $container );
+		$text = trim( $dom->saveHTML( $dom->getElementsByTagName('div')->item( 0 ) ) );
+		$text = substr( $text, strlen( '<div>' ) );
+		$text = substr( $text, 0, -strlen( '</div>' ) );
 
-		while ( $dom->firstChild ) {
-			$dom->removeChild( $dom->firstChild );
-		}
-
-		while ( $container->firstChild ) {
-			$dom->appendChild( $container->firstChild );
-		}
-
-
-		return trim( $dom->saveHTML() );
+		return trim( $text );
 	}
 }
 

--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -172,6 +172,8 @@ class Fixers extends \WP_CLI_Command {
 			exit;
 		}
 
+		\WP_CLI::log( PHP_EOL . 'WARNING: Not extensively tested with non-UTF8.' );
+		\WP_CLI::log( 'WARNING: DOMDocument is likely to make small changes to any HTML as part of its processing.' . PHP_EOL );
 		\WP_CLI::confirm( 'Are you sure you want to run this command? There may be unexpected dragons!' );
 		\WP_CLI::log( 'Finding posts with empty <img src=""> attributes.' );
 		libxml_use_internal_errors( true );

--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -312,7 +312,7 @@ class Fixers extends \WP_CLI_Command {
 			$image_url = $anchor_element->getAttribute( 'href' );
 			$mime_type = wp_check_filetype( $image_url )['type'];
 
-			if ( $mime_type && strpos( $mime_type, 'image/' ) === false ) {
+			if ( ! $mime_type || strpos( $mime_type, 'image/' ) === false ) {
 				continue;
 			}
 

--- a/tests/test-img-src-from-links.php
+++ b/tests/test-img-src-from-links.php
@@ -34,8 +34,8 @@ class Test_Fix_Img_Src_From_Lunks extends \WP_UnitTestCase {
 		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
 
 		$this->assertSame(
-			$output,
-			'Hello <a href="http://example.com/image.jpg"><img src="' . $url . '" alt="paul"></a> world'
+			'Hello <a href="http://example.com/image.jpg"><img src="' . $url . '" alt="paul"></a> world',
+			$output
 		);
 	}
 
@@ -46,8 +46,8 @@ class Test_Fix_Img_Src_From_Lunks extends \WP_UnitTestCase {
 		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
 
 		$this->assertSame(
-			$output,
-			'Hello <a href="http://example.com/image.jpg"><img src="' . $url2 . '" alt="paul"></a> world <a href="http://example.com/image.png"><img src="' . $url1 . '" alt="paul"></a>'
+			'Hello <a href="http://example.com/image.jpg"><img src="' . $url2 . '" alt="paul"></a> world <a href="http://example.com/image.png"><img src="' . $url1 . '" alt="paul"></a>',
+			$output
 		);
 	}
 
@@ -57,8 +57,8 @@ class Test_Fix_Img_Src_From_Lunks extends \WP_UnitTestCase {
 		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
 
 		$this->assertSame(
-			$output,
-			'Hello <a href="http://example.com/image.jpg"><img src="' . $url . '" alt="paul"><img src="' . $url . '" alt="bob"></a> world'
+			'Hello <a href="http://example.com/image.jpg"><img src="' . $url . '" alt="paul"><img src="' . $url . '" alt="bob"></a> world',
+			$output
 		);
 	}
 
@@ -66,15 +66,13 @@ class Test_Fix_Img_Src_From_Lunks extends \WP_UnitTestCase {
 		$text   = 'Hello <a href="http://example.com/image.jpg"><img src="http://example.com/image.gif" alt="paul"></a> world';
 		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
 
-		$this->assertSame( $text, $output );
+		$this->assertSame( $output, $text );
 	}
 
 	public function test_only_replace_image_links() {
 		$text   = 'Hello <a href="http://example.com/some/thing"><img src="" alt="paul"></a> world';
 		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
 
-		$this->assertSame( $text, $output );
+		$this->assertSame( $output, $text );
 	}
-/*
-	*/
 }

--- a/tests/test-img-src-from-links.php
+++ b/tests/test-img-src-from-links.php
@@ -75,4 +75,15 @@ class Test_Fix_Img_Src_From_Lunks extends \WP_UnitTestCase {
 
 		$this->assertSame( $output, $text );
 	}
+
+	public function test_img_src_replacement_with_non_utf8() {
+		$url    = 'http://example.com/image.jpg';
+		$text   = 'На берегу пустынных волн <a href="http://example.com/image.jpg"><img src=""></a>';
+		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
+
+		$this->assertSame(
+			'На берегу пустынных волн <a href="http://example.com/image.jpg"><img src="' . $url . '"></a>',
+			$output
+		);
+	}
 }

--- a/tests/test-img-src-from-links.php
+++ b/tests/test-img-src-from-links.php
@@ -1,0 +1,80 @@
+<?php
+namespace HM\Tests;
+
+/**
+ * @group img-src-from-links
+ */
+class Test_Fix_Img_Src_From_Lunks extends \WP_UnitTestCase {
+	public $old_user_id = 0;
+	public $user_id     = 0;
+	public $factory;
+
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new \WP_UnitTest_Factory;
+
+		// Set current user ID for new posts.
+		$this->user_id = $this->factory->user->create();
+		$this->old_user_id = get_current_user_id();
+
+		wp_set_current_user( $this->user_id );
+	}
+
+	public function tearDown() {
+		wp_set_current_user( $this->old_user_id );
+		parent::tearDown();
+	}
+
+
+	public function test_single_img_src_replacement() {
+		$url    = 'http://example.com/image.jpg';
+		$text   = 'Hello <a href="http://example.com/image.jpg"><img src="" alt="paul"></a> world';
+		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
+
+		$this->assertSame(
+			$output,
+			'Hello <a href="http://example.com/image.jpg"><img src="' . $url . '" alt="paul"></a> world'
+		);
+	}
+
+	public function test_multiple_img_src_replacements() {
+		$url1   = 'http://example.com/image.png';
+		$url2   = 'http://example.com/image.jpg';
+		$text   = 'Hello <a href="http://example.com/image.jpg"><img src="" alt="paul"></a> world <a href="http://example.com/image.png"><img src="" alt="paul"></a>';
+		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
+
+		$this->assertSame(
+			$output,
+			'Hello <a href="http://example.com/image.jpg"><img src="' . $url2 . '" alt="paul"></a> world <a href="http://example.com/image.png"><img src="' . $url1 . '" alt="paul"></a>'
+		);
+	}
+
+	public function test_img_src_replacements_with_multiple_images() {
+		$url    = 'http://example.com/image.jpg';
+		$text   = 'Hello <a href="http://example.com/image.jpg"><img src="" alt="paul"><img src="" alt="bob"></a> world';
+		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
+
+		$this->assertSame(
+			$output,
+			'Hello <a href="http://example.com/image.jpg"><img src="' . $url . '" alt="paul"><img src="' . $url . '" alt="bob"></a> world'
+		);
+	}
+
+	public function test_dont_replace_good_links() {
+		$text   = 'Hello <a href="http://example.com/image.jpg"><img src="http://example.com/image.gif" alt="paul"></a> world';
+		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
+
+		$this->assertSame( $text, $output );
+	}
+
+	public function test_only_replace_image_links() {
+		$text   = 'Hello <a href="http://example.com/some/thing"><img src="" alt="paul"></a> world';
+		$output = \HM\Import\Fixers::replace_img_src_a_href( $text );
+
+		$this->assertSame( $text, $output );
+	}
+/*
+	*/
+}


### PR DESCRIPTION
Built for a client project, we have a problem where some `img src` links are blank, but they are wrapped by `a href` tags. In this case, we are going to fix it by copying the URL from the links into the image src.

These changes implemented a new PR and unit tests.
