### PR TITLE
Img src: remove search term

### DIFF
--- a/hm-import-fixers.php
+++ b/hm-import-fixers.php
@@ -162,7 +162,6 @@ class Fixers extends \WP_CLI_Command {
 		$post_args = array(
 			'offset'           => 0,
 			'posts_per_page'   => $limit,
-			's'                => 'src=""',  // Try to limit the search range.
 			'suppress_filters' => false,
 		);
 


### PR DESCRIPTION
The search term was an optimisation to only operate on posts where we
know they had a blank `img src`. Testing has shown we get images nested
in anchors that go to non-images, which are skipped over.

However, because we don't fix those blank `img src`, if we have more
skipped images than we do the amount of posts we fetch at once
(currently 50), we can end up with a never-ending loop.
